### PR TITLE
Add initial logger

### DIFF
--- a/_modules/cis.py
+++ b/_modules/cis.py
@@ -1,5 +1,8 @@
+import logging
+
 import salt
 
+log = logging.getLogger(__name__)
 
 # Define the module's virtual name
 __virtualname__ = 'cis'


### PR DESCRIPTION
Add logger to cis module. The logger can call the logger from custom modules to write message to minion logs, e.g.:

```python
log.info('Here is Some Information')
log.warning('You Should Not Do That')
log.error('It Is Busted')
```

As a rule, logging should not be done anywhere in a Salt module before it is loaded. For more information see: https://docs.saltstack.com/en/latest/ref/modules/#logging-restrictions