### PR TITLE
Update module documentation

### DIFF
--- a/_modules/cis.py
+++ b/_modules/cis.py
@@ -1,3 +1,14 @@
+# -*- coding: utf-8 -*-
+'''
+A module to CIS benchmark/audit your machines using SaltStack.
+
+:maintainer:    Haije Ploeg
+:maturity:      new
+:platform:      rhel,debian
+'''
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import salt libs
 import salt
 
 


### PR DESCRIPTION
Update module documentation to add execution module metadata, for more information see: https://docs.saltstack.com/en/latest/ref/modules/#add-execution-module-metadata.

And add __future__ imports for backwards compatibility with Python 2.7.